### PR TITLE
specify include directories for build interface

### DIFF
--- a/mtp/CMakeLists.txt
+++ b/mtp/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(mixedTeamProtocol
     src/RoleAllocation.cpp
     src/PlayerId.cpp
     src/Player.cpp)
+add_library(MTP::mixedTeamProtocol ALIAS mixedTeamProtocol)
 target_link_libraries(mixedTeamProtocol RtDBrtdb)
 target_include_directories(mixedTeamProtocol
     PUBLIC


### PR DESCRIPTION
Update to find header files in projects that include mixed team protocol as submodule